### PR TITLE
Cookie security, logout, removal of verify

### DIFF
--- a/src/__test__/auth-router.test.js
+++ b/src/__test__/auth-router.test.js
@@ -230,30 +230,4 @@ describe('Testing Auth router', () => {
         )
     )
   })
-
-  describe('Testing GET /verify token verify', () => {
-    test('It should return 200 and the user belonging to the token', () =>
-      mockUser.createOne()
-        .then(user =>
-          superagent.post(`${API_URL}/verify`)
-            .send({token: user.token})
-            .then(res => {
-              expect(res.status).toEqual(200)
-              expect(res.body.username).toEqual(user.username)
-              expect(res.body.displayName).toEqual(user.displayName)
-            })
-        )
-    )
-
-    test('It should return 401 unauthorized - bad token', () =>
-      superagent.post(`${API_URL}/verify`)
-        .send({token: 'asdsadasdasdasdasdsa'})
-        .then(res => {
-          throw res
-        })
-        .catch(err => {
-          expect(err.status).toEqual(401)
-        })
-    )
-  })
 })

--- a/src/__test__/auth-router.test.js
+++ b/src/__test__/auth-router.test.js
@@ -230,4 +230,33 @@ describe('Testing Auth router', () => {
         )
     )
   })
+
+  describe('Testing GET /logout logout', () => {
+    test('It should return 200 and clear the users token seed from the db', () => {
+      let username
+      return mockUser.createOne()
+        .then(user => {
+          ({username} = user) // destructuring without let/var/const before it requires () around it
+          let basic = util.btoa(`${user.username}:${user.password}`)
+          return superagent.get(`${API_URL}/auth`)
+            .set('Authorization', `Basic ${basic}`)
+        })
+        .then(res => {
+          expect(res.status).toEqual(200)
+          expect(res.text).toBeDefined()
+          return superagent.get(`${API_URL}/logout`)
+            .set('Authorization', `Bearer ${res.text}`)
+        })
+        .then(res => {
+          expect(res.status).toEqual(200)
+          return User.findOne({username})
+        })
+        .then(user => {
+          expect(user.username).toBeDefined()
+          expect(user.displayName).toBeDefined()
+          expect(user.passwordHash).toBeDefined()
+          expect(user.tokenSeed).toBeUndefined()
+        })
+    })
+  })
 })

--- a/src/middleware/bearer-auth.js
+++ b/src/middleware/bearer-auth.js
@@ -26,7 +26,7 @@ export default (req, res, next) => {
   // jwt.verify => Promise
   // Run the bearer token against the server SECRET to see if it's valid and belongs to a user
   util.promisify(jwt.verify)(token, process.env.SECRET)
-    .then(({randomHash}) => User.findOne({randomHash}))
+    .then(({tokenSeed}) => User.findOne({tokenSeed}))
     .then(user => {
       if(!user)
         throw createError(401, '__AUTH_ERROR__ User not found (bearerAuth)')

--- a/src/middleware/bearer-auth.js
+++ b/src/middleware/bearer-auth.js
@@ -33,5 +33,5 @@ export default (req, res, next) => {
       req.user = user // Put the found user onto the request and move to the next module
       next()
     })
-    .catch(err => createError(401, err))
+    .catch(next)
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -12,7 +12,7 @@ const userSchema = new mongoose.Schema({
   username: {type: String, required: true, unique: true},
   displayName: {type: String, required: true, unique: true},
   passwordHash: {type: String},
-  tokenSeed: {type: String, default: ''},
+  tokenSeed: {type: String},
 })
 
 userSchema.methods.passwordHashCompare = function(password) { // no arrow because of context
@@ -32,6 +32,11 @@ userSchema.methods.tokenCreate = function() { // no arrow because of context
   return this.save()
     .then(user => jwt.sign({tokenSeed: this.tokenSeed}, process.env.SECRET))
     .then(token => token)
+}
+
+userSchema.methods.logout = function() {
+  this.tokenSeed = undefined
+  return this.save()
 }
 
 const User = mongoose.model('user', userSchema)

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -87,11 +87,10 @@ authRouter.put('/auth', bearerAuth, jsonParser, (req, res, next) => {
     return res.sendStatus(400)
   }
 
-  User.fromToken(req.headers.authorization.split('Bearer ')[1])
-    .then(user => user.passwordHashCompare(passwords.oldPassword))
-    .then(user => bcrypt.hash(passwords.newPassword, 1)
-      .then(passwordHash => User.findOneAndUpdate({username: user.username}, {passwordHash})))
-    .then(user => res.sendStatus(200))
+  req.user.passwordHashCompare(passwords.oldPassword)
+    .then(user => bcrypt.hash(passwords.newPassword, 1))
+    .then(passwordHash => User.findOneAndUpdate({username: req.user.username}, {passwordHash}))
+    .then(() => res.sendStatus(200))
     .catch(next)
 })
 

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -19,7 +19,7 @@ authRouter.post('/auth', jsonParser, (req, res, next) => {
     ip: req.ip,
     ips: req.ips,
   }
-  console.log('__LOG__ POST /auth register user', {...user, password: null})
+  console.log('__LOG__ POST /auth register user', {...user, password: null, password2: null})
   util.devLog('User with password: ', user)
   console.log('Request Info', requestInfo)
 

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -94,7 +94,7 @@ authRouter.put('/auth', bearerAuth, jsonParser, (req, res, next) => {
     .catch(next)
 })
 
-req.get('/logout', bearerAuth, (req, res, next) => {
+authRouter.get('/logout', bearerAuth, (req, res, next) => {
   let requestInfo = {
     headers: req.headers,
     hostname: req.hostname,

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -39,7 +39,7 @@ authRouter.post('/auth', jsonParser, (req, res, next) => {
   new User.createFromSignup(user)
     .then(user => user.tokenCreate())
     .then(token => {
-      res.cookie('X-VtT-Token', token)
+      res.cookie('X-VtT-Token', token, {maxAge: 86400000, httpOnly: true, secure: true})
       res.send(token)
     })
     .catch(next)
@@ -58,7 +58,7 @@ authRouter.get('/auth', basicAuth, (req, res, next) => {
 
   req.user.tokenCreate()
     .then(token => {
-      res.cookie('X-VtT-Token', token)
+      res.cookie('X-VtT-Token', token, {maxAge: 86400000, httpOnly: true, secure: true})
       res.send(token)
     })
     .catch(next)
@@ -92,6 +92,10 @@ authRouter.put('/auth', bearerAuth, jsonParser, (req, res, next) => {
     .then(passwordHash => User.findOneAndUpdate({username: req.user.username}, {passwordHash}))
     .then(() => res.sendStatus(200))
     .catch(next)
+})
+
+req.get('/logout', bearerAuth, (req, res, next) => {
+  res.clearCookie('X-VtT-Token')
 })
 
 export default authRouter

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -94,22 +94,4 @@ authRouter.put('/auth', bearerAuth, jsonParser, (req, res, next) => {
     .catch(next)
 })
 
-// Verify a user belongs to the incoming token
-authRouter.post('/verify', jsonParser, (req, res, next) => {
-  let {token} = req.body
-  let requestInfo = {
-    headers: req.headers,
-    hostname: req.hostname,
-    ip: req.ip,
-    ips: req.ips,
-  }
-  console.log('__LOG__ GET /verify token verification')
-  util.devLog('Token: ', token)
-  console.log('Request Info', requestInfo)
-
-  User.fromToken(token)
-    .then(user => res.json(user))
-    .catch(() => res.sendStatus(401))
-})
-
 export default authRouter

--- a/src/routers/auth.js
+++ b/src/routers/auth.js
@@ -95,7 +95,21 @@ authRouter.put('/auth', bearerAuth, jsonParser, (req, res, next) => {
 })
 
 req.get('/logout', bearerAuth, (req, res, next) => {
-  res.clearCookie('X-VtT-Token')
+  let requestInfo = {
+    headers: req.headers,
+    hostname: req.hostname,
+    ip: req.ip,
+    ips: req.ips,
+  }
+  console.log('__LOG__ GET /logout logout')
+  console.log('Request Info', requestInfo)
+
+  req.user.logout()
+    .then(() => {
+      res.clearCookie('X-VtT-Token')
+      res.sendStatus(200)
+    })
+    .catch(next)
 })
 
 export default authRouter

--- a/src/routers/document.js
+++ b/src/routers/document.js
@@ -12,16 +12,13 @@ const documentRouter = new Router()
 documentRouter.post('/document', bearerAuth, jsonParser, (req, res, next) => {
   let doc = req.body
   console.log('__LOG__ POST /document new document', doc)
+  console.log('__LOG__ POST /document ownerId', req.user._id)
 
-  User.fromToken(req.headers.authorization.split('Bearer ')[1])
-    .then(user => {
-      console.log('__LOG__ POST /document ownerId', user._id)
-      doc.ownerId = user._id
-      new Document(doc)
-        .save()
-        .then(document => res.json(document))
-        .catch(next)
-    })
+  doc.ownerId = req.user._id
+  new Document(doc)
+    .save()
+    .then(document => res.json(document))
+    .catch(next)
 })
 
 // View a specific document

--- a/src/routers/document.js
+++ b/src/routers/document.js
@@ -14,8 +14,7 @@ documentRouter.post('/document', bearerAuth, jsonParser, (req, res, next) => {
   console.log('__LOG__ POST /document new document', doc)
   console.log('__LOG__ POST /document ownerId', req.user._id)
 
-  doc.ownerId = req.user._id
-  new Document(doc)
+  new Document({...doc, ownerId: req.user._id})
     .save()
     .then(document => res.json(document))
     .catch(next)


### PR DESCRIPTION
I figured out what the problem was with bearer auth. It was finding a user (or not) and then I was finding that same user or the correct user again so there weren't any errors. When I stopped finding it twice, then it required bearer auth to function correctly which threw errors because I didn't realize before. Now that's fixed and cookies are set with an expire date, httponly, and secure. I removed the verify by token function because it's redundant with bearer auth working correctly now.

I added a logout route and method on the model to remove the token seed from the db and clear the cookie so they don't have a working token sitting there all the time.