### PR TITLE
Pass change fix

### DIFF
--- a/src/__test__/auth-router.test.js
+++ b/src/__test__/auth-router.test.js
@@ -153,6 +153,7 @@ describe('Testing Auth router', () => {
             .send({
               oldPassword: user.password,
               newPassword: '00000000',
+              newPassword2: '00000000',
             })
             .then(res => {
               expect(res.status).toEqual(200)
@@ -185,6 +186,7 @@ describe('Testing Auth router', () => {
             .send({
               oldPassword: user.password,
               newPassword: '12345',
+              newPassword2: '12345',
             })
             .then(res => {
               throw res
@@ -203,6 +205,7 @@ describe('Testing Auth router', () => {
             .send({
               oldPassword: 'notTheRightPassword',
               newPassword: '00000000000000',
+              newPassword2: '00000000000000',
             })
             .then(res => {
               throw res
@@ -220,6 +223,7 @@ describe('Testing Auth router', () => {
             .send({
               oldPassword: 'notTheRightPassword',
               newPassword: '00000000000000',
+              newPassword2: '00000000000000',
             })
             .then(res => {
               throw res
@@ -243,6 +247,7 @@ describe('Testing Auth router', () => {
             .send({
               oldPassword: user.password,
               newPassword: '00000000',
+              newPassword2: '00000000',
             })
         )
         .then(res => {

--- a/src/middleware/bearer-auth.js
+++ b/src/middleware/bearer-auth.js
@@ -20,6 +20,7 @@ export default (req, res, next) => {
   let token = authorization.split('Bearer ')[1]
   if(!token) {
     util.securityWarning('Clientside validation bypassed', 'Bearer authorization header has been tampered with', authorization, 'bearerAuth', requestInfo)
+    res.clearCookie('X-VtT-Token')
     return next(createError(401, '__AUTH_ERROR__ Not bearer auth (bearerAuth)'))
   }
 


### PR DESCRIPTION
Session will be destroyed and cookie removed if a client side validation has been bypassed for pass changing. If bearer auth detects tampering, it will destroy their client side cookie but it can't do anything to the server because it doesn't know the real user that is submitting the request. It will just kill their cookie and respond 401.

Added password2 confirmation for pass changing to check if they both matched on the client side and also added a check to make sure the old password is not equal to the new password.